### PR TITLE
Drop support for Python3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         runs-on: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11"]
         include:
           # Include one that runs in the dev environment
           - runs-on: "ubuntu-latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The devcontainer should use the developer target and run as root with podman
 # or docker with user namespaces.
-ARG PYTHON_VERSION=3.12
+ARG PYTHON_VERSION=3.11
 FROM python:${PYTHON_VERSION} as developer
 
 # Add any system dependencies for the developer/build environment here


### PR DESCRIPTION
We have a dev dependency on `ophyd-async` which depends on p4p, see: https://github.com/epics-base/p4p/issues/145