### PR TITLE
Prevent accidental logging by use of Pydantic Secret types, handle envVariables

### DIFF
--- a/src/bluesky_stomp/models.py
+++ b/src/bluesky_stomp/models.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel, ConfigDict, Field
+import os
+
+from pydantic import BaseModel, ConfigDict, Field, Secret, field_validator
 
 
 class BasicAuthentication(BaseModel):
@@ -7,7 +9,14 @@ class BasicAuthentication(BaseModel):
     """
 
     username: str = Field(description="Unique identifier for user")
-    password: str = Field(description="Password to verify user's identity")
+    password: Secret[str] = Field(description="Password to verify user's identity")
+
+    @field_validator("username", "password", mode="before")
+    @classmethod
+    def get_from_env(cls, v: str):
+        if v.startswith("${") and v.endswith("}"):
+            return os.environ[v.removeprefix("${").removesuffix("}").upper()]
+        return v
 
 
 class Broker(BaseModel):

--- a/tests/unit_tests/test_messaging.py
+++ b/tests/unit_tests/test_messaging.py
@@ -389,18 +389,19 @@ def test_connect_passes_basic_auth_details(
     mock_event: Mock,
     mock_connection: Mock,
 ):
+    authentication = BasicAuthentication(
+        username="foo",
+        password="bar",
+    )
     client = StompClient(
         conn=mock_connection,
-        authentication=BasicAuthentication(
-            username="foo",
-            password="bar",
-        ),
+        authentication=authentication,
     )
     mock_connection.is_connected.return_value = False
     client.connect()
     mock_connection.connect.assert_called_once_with(
-        username="foo",
-        passcode="bar",
+        username=authentication.username,
+        passcode=authentication.password,
         wait=True,
     )
 

--- a/tests/unit_tests/test_messaging.py
+++ b/tests/unit_tests/test_messaging.py
@@ -391,7 +391,7 @@ def test_connect_passes_basic_auth_details(
 ):
     authentication = BasicAuthentication(
         username="foo",
-        password="bar",
+        password="bar",  # type: ignore  https://github.com/pydantic/pydantic/issues/9557
     )
     client = StompClient(
         conn=mock_connection,


### PR DESCRIPTION
Required for https://github.com/DiamondLightSource/blueapi/issues/636

Current parsing of blueapi config passes a blueapi BasicAuthentication with fields username, passcode as an instance of bluesky-stomp BasicAuthentication with fields username, password. I am not certain that we would be able to pass the former as an instance of the latter even if their arguments agreed, as they are different Pydantic models. By moving the parsing of environment variables into this class, we can simply make use of this library's BasicAuthentication as part of the config of blueapi and not duplicate the logic.

We additionally noticed logging of passwords, so making the password field a Secret[str] was a sensible move. Note that type checking does not like passing a str as a Secret[str]: https://github.com/pydantic/pydantic/issues/9557