### PR TITLE
Hotfix: Unwrap Secret str value during Stomp connect frame

### DIFF
--- a/src/bluesky_stomp/messaging.py
+++ b/src/bluesky_stomp/messaging.py
@@ -325,7 +325,7 @@ class StompClient:
         if self._authentication is not None:
             self._conn.connect(  # type: ignore
                 username=self._authentication.username,
-                passcode=self._authentication.password,
+                passcode=self._authentication.password.get_secret_value(),
                 wait=True,
             )
         else:

--- a/src/bluesky_stomp/models.py
+++ b/src/bluesky_stomp/models.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel, ConfigDict, Field
+import os
+
+from pydantic import BaseModel, ConfigDict, Field, Secret, field_validator
 
 
 class BasicAuthentication(BaseModel):
@@ -7,7 +9,14 @@ class BasicAuthentication(BaseModel):
     """
 
     username: str = Field(description="Unique identifier for user")
-    password: str = Field(description="Password to verify user's identity")
+    password: Secret[str] = Field(description="Password to verify user's identity")
+
+    @field_validator("username", "password", mode="before")
+    @classmethod
+    def get_from_env(cls, v: str):
+        if v.startswith("${") and v.endswith("}"):
+            return os.environ[v.removeprefix("${").removesuffix("}").upper()]
+        return v
 
 
 class Broker(BaseModel):

--- a/tests/unit_tests/test_messaging.py
+++ b/tests/unit_tests/test_messaging.py
@@ -401,7 +401,7 @@ def test_connect_passes_basic_auth_details(
     client.connect()
     mock_connection.connect.assert_called_once_with(
         username=authentication.username,
-        passcode=authentication.password,
+        passcode=authentication.password.get_secret_value(),
         wait=True,
     )
 

--- a/tests/unit_tests/test_messaging.py
+++ b/tests/unit_tests/test_messaging.py
@@ -389,18 +389,19 @@ def test_connect_passes_basic_auth_details(
     mock_event: Mock,
     mock_connection: Mock,
 ):
+    authentication = BasicAuthentication(
+        username="foo",
+        password="bar",
+    )
     client = StompClient(
         conn=mock_connection,
-        authentication=BasicAuthentication(
-            username="foo",
-            password="bar",
-        ),
+        authentication=authentication,
     )
     mock_connection.is_connected.return_value = False
     client.connect()
     mock_connection.connect.assert_called_once_with(
-        username="foo",
-        passcode="bar",
+        username=authentication.username,
+        passcode=authentication.password,
         wait=True,
     )
 

--- a/tests/unit_tests/test_messaging.py
+++ b/tests/unit_tests/test_messaging.py
@@ -391,7 +391,7 @@ def test_connect_passes_basic_auth_details(
 ):
     authentication = BasicAuthentication(
         username="foo",
-        password="bar",
+        password="bar",  # type: ignore  https://github.com/pydantic/pydantic/issues/9557
     )
     client = StompClient(
         conn=mock_connection,


### PR DESCRIPTION
Wrapping BasicAuthentication password with Pydantic Secret to prevent accidental logging requires unwrapping the password before passing to the Stomp connect frame, as Secret("*******") is Not the value contained within it.

Alternative solution would be to rename the Secret field and make a property with the original name that exposed the get_secret_value.