### PR TITLE
Stop special casing pydantic models in serialization

### DIFF
--- a/src/bluesky_stomp/serdes.py
+++ b/src/bluesky_stomp/serdes.py
@@ -25,15 +25,8 @@ def serialize_message(message: Any) -> bytes:
         str: The serialized object
     """
 
-    if isinstance(message, BaseModel):
-        # Serialize by alias so that our camelCase models leave the service
-        # with camelCase field names
-        json_serializable = message.model_dump(by_alias=True)
-    else:
-        json_serializable = message
-
     return orjson.dumps(
-        json_serializable,
+        message,
         option=orjson.OPT_SERIALIZE_NUMPY,
         default=_fallback_serialize,
     )
@@ -97,6 +90,10 @@ def determine_callback_deserialization_type(
 
 
 def _fallback_serialize(obj: Any) -> Any:
-    if isinstance(obj, set):
+    if isinstance(obj, BaseModel):
+        # Serialize by alias so that our camelCase models leave the service
+        # with camelCase field names
+        return obj.model_dump(by_alias=True)
+    elif isinstance(obj, set):
         return list(cast(set[Any], obj))
     raise TypeError(f"Type {type(obj)} not serializable")

--- a/tests/unit_tests/test_serdes.py
+++ b/tests/unit_tests/test_serdes.py
@@ -101,6 +101,9 @@ DE_SERIALIZATION_TEST_CASES = [
         b'{"unique":[1,2,3],"repeated":[1,1,2,2,3,3]}',
         Bar,
     ),
+    DeAndSerializationTestCase(
+        [Foo(bar=1, baz="one")], b'[{"bar":1,"baz":"one"}]', list[Foo]
+    ),
 ]
 
 


### PR DESCRIPTION
Instead of handling pydantic models before passing them to the orjson
serializer, move the handling into the existing fallback/default
handler. This keeps all custom handling in one place and allows
additional types (such as `list[Model]`) to be serialized.
