### PR TITLE
Correct serialize_message docstring types

### DIFF
--- a/src/bluesky_stomp/serdes.py
+++ b/src/bluesky_stomp/serdes.py
@@ -22,7 +22,7 @@ def serialize_message(message: Any) -> bytes:
         obj: The object to serialize
 
     Returns:
-        str: The serialized object
+        bytes: The serialized object
     """
 
     if isinstance(message, BaseModel):


### PR DESCRIPTION
orjson.dumps returns bytes instead of str. The function annotation was
correct but the docstring didn't match.
